### PR TITLE
chore: deploy with Juno GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,13 +43,9 @@ jobs:
       - name: Setup NodeJS
         uses: ./.github/actions/setup-node
 
-      - name: Install Juno CLI
-        run: pnpm add -g @junobuild/cli
-
-      - name: Build
-        run: pnpm build
-
       - name: Deploy to Juno
-        run: pnpm run deploy
+        uses: junobuild/juno-action@main
+        with:
+          args: deploy
         env:
           JUNO_TOKEN: ${{ secrets.JUNO_TOKEN }}


### PR DESCRIPTION
I did **not** test but, you might be able to simplify the GitHub Actions with following:

- Remove `pnpm build`. It will be performed by the `predeploy` step of the CLI

- Use the [Juno GitHub Action](https://juno.build/docs/guides/github-actions#3-create-the-github-action) instead of installing the CLI